### PR TITLE
 Add missing permission 

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -23,7 +23,7 @@ jobs:
       contents: read
       actions: read
       packages: write
-      issues: read
+      issues: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Action workflow needs to be able to write issues to create an issue (oops)